### PR TITLE
Import legacy date format validator from Laravel 5.1

### DIFF
--- a/src/IntelliHR/Validation/Validators/LegacyDateFormat.php
+++ b/src/IntelliHR/Validation/Validators/LegacyDateFormat.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace IntelliHR\Validation\Validators;
+
+use Illuminate\Contracts\Validation\Validator;
+
+class LegacyDateFormat extends AbstractValidator
+{
+    /**
+     * Name of the validator
+     *
+     * @var string
+     */
+    public static $name = 'legacy_date_format';
+
+    /**
+     * Fallback message
+     *
+     * @var string
+     */
+    public static $message = ':attribute has an invalid date format';
+
+    public function validateLegacyDateFormat(
+        $attribute,
+        $value,
+        $parameters,
+        Validator $validator
+    )  {
+        $this->requireParameterCount(1, $parameters, 'date_format');
+
+        if (!is_string($value) && !is_numeric($value)) {
+            return false;
+        }
+
+        $parsed = date_parse_from_format($parameters[0], $value);
+
+        return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
+    }
+}

--- a/tests/Validators/LegacyDateFormatTest.php
+++ b/tests/Validators/LegacyDateFormatTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace IntelliHR\Tests\Validation\Validators;
+
+use IntelliHR\Tests\Validation\BaseTestCase;
+use IntelliHR\Validation\Validators\LegacyDateFormat;
+
+class LegacyDateFormatTest extends BaseTestCase
+{
+    /**
+     * @var LegacyDateFormat
+     */
+    protected $validator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->validator = new LegacyDateFormat();
+    }
+
+    /**
+     * @dataProvider data
+     *
+     * @param string $attribute
+     * @param string $value
+     * @param array $parameters
+     * @param bool $expected
+     */
+    public function testValidatesAsExpected(
+        string $attribute,
+        string $value,
+        array $parameters,
+        bool $expected
+    ) {
+        $result = $this
+            ->validator
+            ->validateLegacyDateFormat(
+                $attribute,
+                $value,
+                $parameters,
+                $this->laravelValidator
+            );
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function data(): array
+    {
+        return [
+            [
+                'attribute' => 'start_date',
+                'value' => '2018-01-01 00:00:00+00',
+                'parameters' => [
+                    'Y-m-d H:i:sO'
+                ],
+                'expected' => true,
+            ], [
+                'attribute' => 'start_date',
+                'value' => '1997-04-23 14:00:00+10',
+                'parameters' => [
+                    'Y-m-d H:i:sO'
+                ],
+                'expected' => true,
+            ],[
+                'attribute' => 'start_date',
+                'value' => '2018-01-01 00:00',
+                'parameters' => [
+                    'Y-m-d H:i'
+                ],
+                'expected' => true,
+            ], [
+                'attribute' => 'start_date',
+                'value' => '2018-01-01',
+                'parameters' => [
+                    'Y-m-d'
+                ],
+                'expected' => true,
+            ], [
+                'attribute' => 'start_date',
+                'value' => '2018-01-01 00:00:00',
+                'parameters' => [
+                    'Y-m-d H:i:sO'
+                ],
+                'expected' => false,
+            ], [
+                'attribute' => 'start_date',
+                'value' => '2018-01-01 00:00',
+                'parameters' => [
+                    'Y-m-d H:i:sO'
+                ],
+                'expected' => false,
+            ], [
+                'attribute' => 'start_date',
+                'value' => '2018-01-01',
+                'parameters' => [
+                    'Y-m-d H:i:sO'
+                ],
+                'expected' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
In Laravel 5.4 and above the validation for dates changed from a simple
parse check to making sure that the date format will both parse and then
re-formats back to the same value [1]. This causes issues for a lot of
the dates we use which are in PostgreSQL ISO8601 format [2] which only
uses 2 numbers for the timezone offset, which PHP doesn't have an output
format string for.

[1]
https://github.com/laravel/framework/blob/7bd8c6e44fa12b8ac30bfa97bf87deb12bd05ca7/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L394
[2]
https://www.postgresql.org/docs/9.6/static/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT